### PR TITLE
Add attr_latex customization.

### DIFF
--- a/org-download.el
+++ b/org-download.el
@@ -136,8 +136,13 @@ will be used."
           (const :tag "screencapture" "screencapture -i %s"))
   :group 'org-download)
 
-(defcustom org-download-image-width 0
+(defcustom org-download-image-html-width 0
   "When non-zero add #+attr_html: :width tag to the image."
+  :type 'integer
+  :group 'org-download)
+
+(defcustom org-download-image-latex-width 0
+  "When non-zero add #+attr_latex: :width tag to the image."
   :type 'integer
   :group 'org-download)
 
@@ -317,12 +322,14 @@ It's inserted before the image link and is used to annotate it.")
   (insert
    (concat
     (funcall org-download-annotate-function link)
-    (format "\n%s[[file:%s]]"
-            (if (= org-download-image-width 0)
-                ""
-              (format
-               "#+attr_html: :width %dpx\n" org-download-image-width))
-            (file-relative-name filename (file-name-directory (buffer-name))))))
+    "\n"
+    (if (= org-download-image-html-width 0)
+        ""
+      (format "#+attr_html: :width %dpx\n" org-download-image-html-width))
+    (if (= org-download-image-latex-width 0)
+        ""
+      (format "#+attr_latex: :width %dcm\n" org-download-image-latex-width))
+    (format "[[file:%s]]" (file-relative-name filename (file-name-directory (buffer-name))))))
   (org-display-inline-images))
 
 (defun org-download--at-comment-p ()


### PR DESCRIPTION
Support for latex attribute of image width, which usually in `cm` or `em`.