### PR TITLE
Refactor code (Extracting variables and functions)

### DIFF
--- a/org-download.el
+++ b/org-download.el
@@ -281,6 +281,10 @@ The screenshot tool is determined by `org-download-screenshot-method'."
   "Function that takes LINK and returns a string.
 It's inserted before the image link and is used to annotate it.")
 
+(defvar org-download-link-format
+  "[[file:%s]]"
+  "Format of the file link to insert.")
+
 (defun org-download-image (link)
   "Save image at address LINK to `org-download--dir'."
   (interactive "sUrl: ")
@@ -329,7 +333,7 @@ It's inserted before the image link and is used to annotate it.")
     (if (= org-download-image-latex-width 0)
         ""
       (format "#+attr_latex: :width %dcm\n" org-download-image-latex-width))
-    (format "[[file:%s]]" (file-relative-name filename (file-name-directory (buffer-name))))))
+    (format org-download-link-format (file-relative-name filename (file-name-directory (buffer-name))))))
   (org-display-inline-images))
 
 (defun org-download--at-comment-p ()

--- a/org-download.el
+++ b/org-download.el
@@ -187,7 +187,7 @@ The directory is created if it didn't exist before."
 (defun org-download--fullname (link &optional ext)
   "Return the file name where LINK will be saved to.
 
-It's affected by `org-download-timestamp' and `org-download--dir'.
+It's affected by `org-download--dir'.
 EXT can hold the file extension, in case LINK doesn't provide it."
   (let ((filename
          (file-name-nondirectory
@@ -198,11 +198,16 @@ EXT can hold the file extension, in case LINK doesn't provide it."
       (setq filename (replace-match "" nil nil filename 1)))
     (abbreviate-file-name
      (expand-file-name
-      (format "%s%s.%s"
-              (file-name-sans-extension filename)
-              (format-time-string org-download-timestamp)
-              (or ext (file-name-extension filename)))
+      (org-download--fullname-format filename ext)
       dir))))
+
+(defun org-download--fullname-format (filename &optional ext)
+  "It's affected by `org-download-timestamp'.
+EXT can hold the file extension, in case FILENAME doesn't provide it."
+  (format "%s%s.%s"
+          (file-name-sans-extension filename)
+          (format-time-string org-download-timestamp)
+          (or ext (file-name-extension filename))))
 
 (defun org-download--image (link filename)
   "Save LINK to FILENAME asynchronously and show inline images in current buffer."


### PR DESCRIPTION
### Aims of the PR

#### 1. `org-download-link-format`
I want to insert "[[./%s]]" instead of "[[file:%s]]".

#### 2. `org-download--fullname`
Due to filename restrictions of ImageMagick, I have to do:
```
         (replace-regexp-in-string fullname " " "-")
```
inside the full name function. I didn't think it's a good idea to override the entire `org-download--fullname`, so I extracted the part that was actually generating the full name.