### PR TITLE
fix for org-download--delete

### DIFF
--- a/org-download.el
+++ b/org-download.el
@@ -392,7 +392,7 @@ When TIMES isn't nil, delete only TIMES links."
   (save-excursion
     (goto-char beg)
     (while (and (>= (decf times) 0)
-                (re-search-forward "\\[\\[\\([^]]*\\)\\]\\]" end t))
+                (re-search-forward "\\[\\[file:\\([^]]*\\)\\]\\]" end t))
       (let ((str (match-string-no-properties 1)))
         (delete-region beg
                        (match-end 0))


### PR DESCRIPTION
when i use 'org-download-delete', it fails to delete the image file.

then i check the source, i find the regexp in 'org-download--delete' maybe not correct.

i changed it, and test here successfully.

thank you for the perfect package.