### PR TITLE
Add org-download-image-html-title. If set add a "title" attribute.

### DIFF
--- a/org-download.el
+++ b/org-download.el
@@ -143,6 +143,11 @@ will be used."
           )
   :group 'org-download)
 
+(defcustom org-download-image-html-title ""
+  "When set add #+attr_html: :title tag to the image."
+  :type 'string
+  :group 'org-download)
+
 (defcustom org-download-image-html-width 0
   "When non-zero add #+attr_html: :width tag to the image."
   :type 'integer
@@ -342,6 +347,9 @@ It's inserted before the image link and is used to annotate it.")
    (concat
     (funcall org-download-annotate-function link)
     "\n"
+    (if (string= org-download-image-html-title "")
+        ""
+      (format "#+attr_html: :title %s\n" org-download-image-html-title))
     (if (= org-download-image-html-width 0)
         ""
       (format "#+attr_html: :width %dpx\n" org-download-image-html-width))


### PR DESCRIPTION
Hi Oleh,

I've added to org-download the possibility to have an HTML title attribute set when inserting an image into a buffer:

```
(defcustom org-download-image-html-title ""
  "When set add #+attr_html: :title tag to the image."
  :type 'string
  :group 'org-download)
```

Please let me know if you think it might be a good idea to merge it to your master branch.

Have a nice day and regards,
Davide