### PR TITLE
org-download.el (org-download-yank): Add ability to trim newline

### DIFF
--- a/org-download.el
+++ b/org-download.el
@@ -285,9 +285,13 @@ COMMAND is a format-style string with two slots for LINK and FILENAME."
    nil t))
 
 (defun org-download-yank ()
-  "Call `org-download-image' with current kill."
+  "Call `org-download-image' with current kill.
+Trim newline if current kill contains one"
   (interactive)
-  (org-download-image (current-kill 0)))
+  (org-download-image
+   (if (string-match-p "\n$" (current-kill 0))
+       (replace-regexp-in-string "\n$" ""  (current-kill 0))
+     (current-kill 0))))
 
 (defun org-download-screenshot ()
   "Capture screenshot and insert the resulting file.


### PR DESCRIPTION
Trim newline, if image url contains one

Scenario:

1) user get image path from script

```
exec maim $HOME/Pictures/screenshot/$(date +%F-%T).png & exec echo $HOME/Pictures/screenshot/$(date +%F-%T).png | xclip -selection clipboard
```

Url contains : "/home/user/Pictures/screenshot/2019-01-11-18:10:20.png\n"

Trim newline with `(replace-regexp-in-string "\n$" ""  (current-kill 0))`

2) if this PR not accepted, user modify the screenshot script with `tr`:

```
exec maim $HOME/Pictures/screenshot/$(date +%F-%T).png & exec echo $HOME/Pictures/screenshot/$(date +%F-%T).png | tr -d '\n' | xclip -selection clipboard
```