### PR TITLE
Add ability to delete image after download

### DIFF
--- a/org-download.el
+++ b/org-download.el
@@ -169,6 +169,10 @@ will be used."
   :type 'integer
   :group 'org-download)
 
+(defcustom org-download-delete-image-after-download nil
+  "When non-nil delete local image after download."
+  :group 'org-download)
+
 (defun org-download-get-heading (lvl)
   "Return the heading of the current entry's LVL level parent."
   (save-excursion
@@ -352,6 +356,9 @@ It's inserted before the image link and is used to annotate it.")
         (org-download--image link filename)
         (when (eq org-download-method 'attach)
           (org-attach-attach filename nil 'none))
+        (when (and (eq org-download-delete-image-after-download t)
+                   (eq (url-handler-file-remote-p (current-kill 0)) nil))
+          (delete-file link delete-by-moving-to-trash))
         (org-download-insert-link link filename)))))
 
 (defun org-download-rename-at-point ()


### PR DESCRIPTION
Sometimes we want to keep our screenshot/pictures clean. Deleting screenshot manually after org-download tedious. Org-download with `'directory` mechanism already copy file to specified `directory`. So keeping duplicate screenshot is a mess.

Set `org-download-delete-image-after-download` to non-nil to delete image after dragging/yanking it.