### PR TITLE
Use expand-file-name to create filepath

### DIFF
--- a/org-download.el
+++ b/org-download.el
@@ -247,7 +247,7 @@ The directory is created if it didn't exist before."
       (let* ((part1 (org-download--dir-1))
              (part2 (org-download--dir-2))
              (dir (if part2
-                      (format "%s/%s" part1 part2)
+                      (expand-file-name part2 part1)
                     part1)))
         (unless (file-exists-p dir)
           (make-directory dir t))


### PR DESCRIPTION
Address path1 may have slash suffix.

``` emacs-lisp
(setq path1 "./img/")
;;=> "./img/"

(setq path2 "1")
;;=> "1"

(format "%s/%s" path1 path2)
;;=> "./img//1"

(expand-file-name path2 path1)
;;=> "/home/conao/img/1"
```