### PR TITLE
org-download.el (org-download-screenshot) : don't insert screenshot on cancel

### DIFF
--- a/org-download.el
+++ b/org-download.el
@@ -356,7 +356,9 @@ The screenshot tool is determined by `org-download-screenshot-method'."
       (shell-command-to-string
        (format org-download-screenshot-method
                org-download-screenshot-file))))
-  (org-download-image org-download-screenshot-file))
+  (when (file-exists-p org-download-screenshot-file)
+    (org-download-image org-download-screenshot-file)
+    (delete-file org-download-screenshot-file)))
 
 (declare-function org-attach-dir "org-attach")
 (declare-function org-attach-attach "org-attach")


### PR DESCRIPTION
Screenshot tools return the same 0 exit-code when an attempt is cancelled. Here I use the existence of the temporary file as an indication of user intent. This means we need to clean up the temp file after use.