### PR TITLE
org-download.el (org-download-screenshot-method): Add flameshot

### DIFF
--- a/org-download.el
+++ b/org-download.el
@@ -129,6 +129,7 @@ will be used."
   :type '(choice
           (const :tag "gnome-screenshot" "gnome-screenshot -a -f %s")
           (const :tag "scrot" "scrot -s %s")
+          (const :tag "flameshot" "flameshot gui --raw > %s")
           (const :tag "gm" "gm import %s")
           (const :tag "imagemagick/import" "import %s")
           (const :tag "imagemagick/import + xclip to save to clipboard"


### PR DESCRIPTION
I'm using the excellent [flameshot](https://flameshot.js.org) screenshotting tool and made it work with org-download.