### PR TITLE
Also check if derived-mode-p equals 'org-mode

### DIFF
--- a/org-download.el
+++ b/org-download.el
@@ -203,8 +203,8 @@ For example:
 (declare-function posframe-show "ext:posframe")
 
 (defun org-download-org-mode-p ()
-  "Return `t' if major-mode or derived-mode-p equals 'org-mode."
-  (or (eq major-mode 'org-mode) (derived-mode-p 'org-mode)))
+  "Return `t' if major-mode or derived-mode-p equals 'org-mode, otherwise `nil'."
+  (or (eq major-mode 'org-mode) (when (derived-mode-p 'org-mode) t)))
 
 (defun org-download--display-inline-images ()
   (cond


### PR DESCRIPTION
Hey @abo-abo,

I'm a maintainer of `org-journal`. A user has reported that `org-download` doesn't work in `org-journal` because we derive from `org-mode`. Hence, `major-mode` is `org-journal-mode` not `org-mode`. With this PR we also check if `(derived-mode-p 'org-mode)` returns `t`.

Resolves bastibe/org-journal#236