### PR TITLE
Require cl-lib instead of cl

### DIFF
--- a/org-download.el
+++ b/org-download.el
@@ -70,7 +70,7 @@
 
 
 (eval-when-compile
-  (require 'cl))
+  (require 'cl-lib))
 (require 'async)
 (require 'url-parse)
 (require 'url-http)


### PR DESCRIPTION
cl is deprecated as of Emacs 27.


----

#