### PR TITLE
[feature] add the 3rd method to insert the file path

### DIFF
--- a/org-download.el
+++ b/org-download.el
@@ -446,10 +446,14 @@ It's inserted before the image link and is used to annotate it.")
   :type 'function)
 
 (defcustom org-download-abbreviate-filename-function #'file-relative-name
-  "Function that takes FILENAME and returns an abbreviated file name."
-  :type '(choice
-          (const :tag "relative" file-relative-name)
-          (const :tag "absolute" expand-file-name)))
+    "Function that takes FILENAME and returns an abbreviated file name."
+    :type '(choice
+            (const :tag "relative" file-relative-name)
+            (const :tag "absolute" expand-file-name)
+            (const :tag "rel2home" org-download-return-path-relative-to-home)))
+
+(defun org-download-return-path-relative-to-home (filename-full)
+  (concat (string-remove-prefix (file-truename "~/") filename-full)))
 
 (defun org-download-link-format-function-default (filename)
   "The default function of `org-download-link-format-function'."


### PR DESCRIPTION
Instead of using full path `/home/a-user-name/clip/xxx.png`

Now, the user can have a choice to set the inserted filename as `~/clip/xxx.png`.

This is convenient for multiple computer users.

For user reference, once this feature is approved, then the user can
add the following code to user's `.emacs` file.

```
(setq org-download-abbreviate-filename-function #'org-download-return-path-relative-to-home)
```