### PR TITLE
Use org-link-display-format to extract link text

### DIFF
--- a/org-download.el
+++ b/org-download.el
@@ -76,6 +76,10 @@
 (require 'org)
 (require 'org-attach)
 (require 'org-element)
+(eval-when-compile
+  (when (or (version<= "27.1" emacs-version)
+            (version<= "9.3" org-version))
+    (require 'ol)))
 
 (defgroup org-download nil
   "Image drag-and-drop for org-mode."
@@ -239,8 +243,10 @@ For example:
               (if heading
                   (replace-regexp-in-string
                    " " "_"
-                   (org-link-display-format
-                    heading))
+                   (if (fboundp 'org-link-display-format)
+                       (org-link-display-format
+                        heading)
+                     heading))
                 "")))
         ""))))
 

--- a/org-download.el
+++ b/org-download.el
@@ -239,7 +239,8 @@ For example:
               (if heading
                   (replace-regexp-in-string
                    " " "_"
-                   heading)
+                   (org-link-display-format
+                    heading))
                 "")))
         ""))))
 


### PR DESCRIPTION
Hello,

If the context headline contains a link, the image paths `org-download` produces can become ugly. `org-link-display-format` replace links in a string with their description (or link target if there is no description), which will be useful here.

ol.el is an feature available since Org 9.3 or Emacs 27.1, so I've added a fallback.