### PR TITLE
Update org-download.el to make it compatible with Emacs in WSL

### DIFF
--- a/org-download.el
+++ b/org-download.el
@@ -364,6 +364,21 @@ COMMAND is a format-style string with two slots for LINK and FILENAME."
     (current-buffer))
    nil t))
 
+(defun org-download-wsl-clipboard()
+  "use powershell to catch the clipboard, 
+  to simplify the logic, use c:/Users/Public as temporary directoy, and move it into current directoy"
+  (interactive)
+  (let* ((powershell "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe")
+         (file-name (format-time-string "screenshot_%Y%m%d_%H%M%S.png"))
+         ;; (file-path-powershell (concat "c:/Users/\$env:USERNAME/" file-name))
+         (file-path-wsl (concat "./images/" file-name))
+         )
+    ;; (shell-command (concat powershell " -command \"(Get-Clipboard -Format Image).Save(\\\"C:/Users/\\$env:USERNAME/" file-name "\\\")\""))
+    (shell-command (concat powershell " -command \"(Get-Clipboard -Format Image).Save(\\\"C:/Users/Public/" file-name "\\\")\""))
+    (rename-file (concat "/mnt/c/Users/Public/" file-name) file-path-wsl)
+    (insert (concat "[[file:" file-path-wsl "]]"))
+    (message "insert DONE.")))
+
 (defun org-download-yank ()
   "Call `org-download-image' with current kill."
   (interactive)


### PR DESCRIPTION
Hi, really appreciate your work. But it seems that org-download-clipboard isn't compatible with Emacs in WSL.
So I add a function which uses powershell to read the clipboard and return the images on clipboard to Emacs in WSL. : )