### PR TITLE
org-download.el (org-download-clipboard): Correct ImageMagick's executable name on Windows

### DIFF
--- a/org-download.el
+++ b/org-download.el
@@ -409,10 +409,10 @@ The screenshot tool is determined by `org-download-screenshot-method'."
                 (user-error
                  "Please install the \"xclip\" program"))))
            ((windows-nt cygwin)
-            (if (executable-find "convert")
-                "convert clipboard: %s"
+            (if (executable-find "magick")
+                "magick convert clipboard: %s"
               (user-error
-               "Please install the \"convert\" program included in ImageMagick")))
+               "Please install the \"magick\" program included in ImageMagick")))
            ((darwin berkeley-unix)
             (if (executable-find "pngpaste")
                 "pngpaste %s"


### PR DESCRIPTION
On default installations of ImageMagick on Windows, executables such as `convert.exe` are considered a legacy feature (perhaps due to name collisions with system programs) and as such are not included unless the user asks for it during the installation. Instead, these utilities are treated as subcommands that can be accessed through `magick.exe`.