### PR TITLE
org-download.el (org-download--fullname): A more correct way of setti…

### DIFF
--- a/org-download.el
+++ b/org-download.el
@@ -289,7 +289,7 @@ EXT can hold the file extension, in case LINK doesn't provide it."
     (when (string-match ".*?\\.\\(?:png\\|jpg\\)\\(.*\\)$" filename)
       (setq filename (replace-match "" nil nil filename 1)))
     (when ext
-      (setq filename (concat filename "." ext)))
+      (setq filename (concat (file-name-sans-extension filename) "." ext)))
     (abbreviate-file-name
      (expand-file-name
       (funcall org-download-file-format-function filename)


### PR DESCRIPTION
…ng file extensions

In some cases, simply appending a file extension will cause the resulting filename to have multiple file extensions (ugly!), especially when downloading from URLs. With this change, the function will remove any existing extension before appending a new one.