### PR TITLE
Microsoft Windows improvements, system clipboard and magick

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ Point **A** (*the source*) can be:
 3. A local or remote image address in kill-ring.
    Use the `org-download-yank` command for this.
    Remember that you can use "0 w" in `dired` to get an address.
-4. A screenshot taken using `gnome-screenshot`, `scrot`, `gm`, `xclip`
-   (on Linux), `screencapture` (on OS X) or , `imagemagick/convert`
-   (on Windows).  Use the `org-download-screenshot` command for this.
-   Customize the backend with `org-download-screenshot-method`.
+4. A screenshot taken using `gnome-screenshot`, `scrot`, `gm`, `xclip` (on
+   Linux), `screencapture` (on OS X) or , `imagemagick/convert` or
+   `mswindows-clipboard` (on Windows).  Use the `org-download-screenshot`
+   command for this.  Customize the backend with
+   `org-download-screenshot-method`.
 
 Point **B** (*the target*) is an Emacs `org-mode` buffer where the inline
 link will be inserted.  Several customization options will determine

--- a/org-download.el
+++ b/org-download.el
@@ -151,6 +151,10 @@ will be used."
                  "xclip -selection clipboard -t image/png -o > %s")
           ;; take an image that is already on the clipboard, for Windows
           (const :tag "imagemagick/convert" "magick clipboard: %s")
+          ;; take an image that is already on the Windows clipboard
+          ;; slower than imagemagick but works an all systems
+          (const :tag "mswindows-clipboard"
+                 "powershell -command \"Add-Type -AssemblyName System.Windows.Forms;if ($([System.Windows.Forms.Clipboard]::ContainsImage())) {$image = [System.Windows.Forms.Clipboard]::GetImage();[System.Drawing.Bitmap]$image.Save('c:/users/adanaos/downloads/powershell.png',[System.Drawing.Imaging.ImageFormat]::Png)} \"")
           ;; capture region, for Wayland
           (const :tag "grim + slurp" "grim -g \"$(slurp)\" %s")
           (function :tag "Custom function")))
@@ -410,9 +414,9 @@ The screenshot tool is determined by `org-download-screenshot-method'."
                  "Please install the \"xclip\" program"))))
            ((windows-nt cygwin)
             (if (executable-find "magick")
-                "magick convert clipboard: %s"
-              (user-error
-               "Please install the \"magick\" program included in ImageMagick")))
+                "magick clipboard: %s"
+                ;; fallback for windows always exists
+                "powershell -command \"Add-Type -AssemblyName System.Windows.Forms;if ($([System.Windows.Forms.Clipboard]::ContainsImage())) {$image = [System.Windows.Forms.Clipboard]::GetImage();[System.Drawing.Bitmap]$image.Save('c:/users/adanaos/downloads/powershell.png',[System.Drawing.Imaging.ImageFormat]::Png)} \""))
            ((darwin berkeley-unix)
             (if (executable-find "pngpaste")
                 "pngpaste %s"


### PR DESCRIPTION
- `org-download-screenshot-method` option `mswindows-clipboard` to use powershell to access system clipboard images
- `magick convert` deprecated in 7.0
- add fallback to windows clipboard when `magick` is not found

Tested with emacs 30 running emacs -q and executing:
```
(use-package org-download
  :vc (org-download
       :url "https://github.com/andanao/org-download"
       :main-file "org-download.el"
       :branch "master"
       :rev :newest)
  :hook
  (dired-mode . org-download-enable)
  (org-mode . org-download-enable)
  :custom
  (org-download-method 'attach)
  (org-download-screenshot-method 'mswindows-clipboard)
  )
```