### PR TITLE
Add customize option to remove slashes from directory path

### DIFF
--- a/org-download.el
+++ b/org-download.el
@@ -67,7 +67,6 @@
 ;; (the default) or `wget' or `curl'.
 ;;
 ;;; Code:
-
 
 (require 'cl-lib)
 (require 'async)
@@ -195,6 +194,15 @@ For example:
     (const :tag "Off" nil)
     (const :tag "Posframe" posframe)))
 
+(defcustom org-download-make-sub-directories-from-heading nil
+  "When non-nil make subdirectories based on heading title. You should set this to nil if you are using italics in your org title.
+For example:
+
+  * Hello/World
+
+Stores the image in the directory ./HelloWorld when this variable is non-nil."
+  :type 'boolean)
+
 (defvar org-download-posframe-show-params
   '(;; Please do not remove :timeout or set it to large.
     :timeout 1
@@ -256,6 +264,13 @@ Unless `org-download-heading-lvl' is nil, it's the name of the current
     (org-download-get-heading
      org-download-heading-lvl)))
 
+(defun org-download--santize-path (path)
+  "Replace forward slashes with empty strings in PATH when
+`org-download-make-sub-directories-from-heading' is not nil."
+  (if org-download-make-sub-directories-from-heading
+      (string-replace "/" "" path)
+    path))
+
 (defun org-download--dir ()
   "Return the directory path for image storage.
 
@@ -263,7 +278,7 @@ The path is composed from `org-download--dir-1' and `org-download--dir-2'.
 The directory is created if it didn't exist before."
   (if (org-download-org-mode-p)
       (let* ((part1 (org-download--dir-1))
-             (part2 (org-download--dir-2))
+             (part2 (org-download--santize-path (org-download--dir-2)))
              (dir (if part2
                       (expand-file-name part2 part1)
                     part1)))


### PR DESCRIPTION
Setting org-download-make-sub-directories-from-heading to non nil removes slashes from Org heading when making directories. This helps when downloading images into Org headings with italics, e.g. "* /My Heading/" tries to create a directory in the root directory when this option is not enabled.

I came across an edge case where I was trying to drag and drop images in my org file structured like this:

```org

* /Album Title/ - Band Name

[[IMAGE][IMAGE]]

This is a really great album by a really great band.

* /Album Title/ - Band Name

[[IMAGE][IMAGE]]

This is another great album.

```

Trying to use italics in the org heading for the album title. org-download was treating the heading as a file path so when I dragged and drop my image or trying org-download-clipboard it tried to create a directory at `/Album\ Title/\ -\ Band\ Name` in my root directory.

I added a customize option to sanitize the org header by removing slashes. I set it to `nil` by default to not break existing behavior in case someone is using this to place downloaded images in a specific sub directory based on the heading. But this option will help if someone is using italics in their org headings and does not want org-download to create unexpected sub directories or try create a directory in the root directory.